### PR TITLE
add tests

### DIFF
--- a/tests/testthat/test-writeijroi.R
+++ b/tests/testthat/test-writeijroi.R
@@ -1,0 +1,17 @@
+
+
+path <- file.path(system.file(package = "RImageJROI"), "extdata", "ijroi")
+
+testthat::test_that(
+  desc = "ROI files read and wrote are consistent",
+  code = {
+    name_roi <- dir(path, pattern = "*.roi")
+    
+    for(i in 1:length(name_roi)) {
+      r <- RImageJROI::read.ijroi(file.path(path, name_roi[i]))
+      RImageJROI::write.ijroi(file = paste0("/tmp/", name_roi[i]), roi = r, verbose = F)
+      r_2 <- RImageJROI::read.ijroi(file = paste0("/tmp/", name_roi[i]), verbose = F)
+      testthat::expect_identical(r, r_2)
+    }
+  })
+

--- a/tests/testthat/test-writeijzip.R
+++ b/tests/testthat/test-writeijzip.R
@@ -1,0 +1,13 @@
+
+path <- file.path(system.file(package = "RImageJROI"), "extdata", "ijroi")
+
+testthat::test_that(
+  desc = "ROI zip files read and wrote are consistent",
+  code = {
+    path_roizip <- file.path(path, "ijzip.zip")
+    
+    r <- RImageJROI::read.ijzip(path_roizip)
+    RImageJROI::write.ijzip(file = "/tmp/ijzip.zip", roi = r, verbose = F)
+    r_2 <- RImageJROI::read.ijzip(file = "/tmp/ijzip.zip", verbose = F)
+    testthat::expect_identical(r, r_2)
+  })


### PR DESCRIPTION
write.ijzip does not passed due to the order of ROI files in the variable are different. But, the content of ROI file are correct, thus this will not cause trouble for analysis.